### PR TITLE
Fix typo in query prompt

### DIFF
--- a/query_generator.py
+++ b/query_generator.py
@@ -2,7 +2,7 @@
 def generate_queries(model, question):
     prompt = (
         f"Could you generate 10 relevant and concise search queries for the following research question: {question}? "
-        "Please answer only with the search queries, and separate it by comma's without any additional text."
+        "Please answer only with the search queries, and separate it by commas without any additional text."
     )
     response = model.invoke(prompt)
     return [q.strip() for q in response.content.split(",")]


### PR DESCRIPTION
## Summary
- fix a typo in the query generator prompt

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685546b4ca04832daf12c18e7807c948