### PR TITLE
Add setup info for API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,54 @@
 # ThoughtChain
 
-ThoughtChain is a command-line tool that builds a concise literature review using Semantic Scholar and a language model. It generates search queries, downloads relevant papers, analyzes them and produces a report.
+ThoughtChain is an AI-powered assistant that builds a short literature review for a given research question. It queries Semantic Scholar, downloads open access papers, screens them with a language model and returns a concise scientific report. A small Flask web interface is also provided.
 
-## Setup
+## Installation
 
-1. Install Python 3.8 or newer.
-2. Install the required packages:
-
-```bash
-pip install langchain requests PyMuPDF
-```
-
-3. Provide API keys for OpenAI and Semantic Scholar. You can set them as environment variables:
+1. Install **Python 3.8** or newer.
+2. Install dependencies:
 
 ```bash
-export OPENAI_API_KEY=your-openai-key
-export SEMANTIC_SCHOLAR_API_KEY=your-semanticscholar-key
+pip install -r requirements.txt
+# additional packages for the web app
+pip install flask flask-cors python-dotenv
 ```
 
-If the variables are not set, the program will prompt for the keys when run.
+## Configuration
+
+Create a `.env` file in the project root and add your API keys:
+
+```
+OPENAI_API_KEY=your-openai-key
+SEMANTIC_SCHOLAR_API_KEY=your-semantic-scholar-key
+```
+
+The application loads this file automatically. Keep the `.env` file private and never commit it to version control.
 
 ## Usage
 
-Run the main script and follow the prompts:
+### Command line example
+
+You can call the pipeline directly from Python:
 
 ```bash
-python main.py
+python - <<'PY'
+from main import run_pipeline
+result = run_pipeline("What is the role of epigenetics in Alzheimer's disease?")
+print(result["report"])
+PY
 ```
 
-Enter your research question when asked. The program will fetch papers, analyze them and print the generated report.
+### Web interface
+
+To start the Flask interface run:
+
+```bash
+python app.py
+```
+
+Open `http://127.0.0.1:5000/` in your browser and enter a research question. The page will display each step of the pipeline and the generated report.
+
+## License
+
+This project is licensed under the MIT License. See the `LICENSE` file for details.
+


### PR DESCRIPTION
## Summary
- explain how to place API keys in a `.env` file
- mention Python requirements and how to start the web interface

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686e5e7f1154832d96cc316ab1fc89d0